### PR TITLE
Implement object path

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,6 +16,7 @@ JNIdbus uses annotations and reflection to serialize POJO into DBus messages. Th
 
 - Boolean, Byte, Short, Integer, Long, Double and their primitive equivalent
 - String
+- Object path (mapped on the `String` class)
 - Nested serializable objects
 - Lists
 
@@ -372,7 +373,6 @@ suspend fun suspendingDBusCall() : SingleStringMessage{
 
 ## Planned tasks
 
-- Support `OBJECT_PATH` type
 - Refactor `serialization.cpp` to use proper OOP and cleanup the code
 - Add the capability to create downcasted typed array in JNI code instead of plain `Object[]` objects
 - Use direct `ByteBuffer` instead of plain `Object` arrays to avoid copies.

--- a/README.md
+++ b/README.md
@@ -16,7 +16,8 @@ JNIdbus uses annotations and reflection to serialize POJO into DBus messages. Th
 
 - Boolean, Byte, Short, Integer, Long, Double and their primitive equivalent
 - String
-- Object path (mapped on the `String` class)
+- Object path (mapped on the `ObjectPath` class)
+- Enum (transferred either as String or Integer according to the signature of the message)
 - Nested serializable objects
 - Lists
 

--- a/src/main/java/fr/viveris/jnidbus/serialization/serializers/PrimitiveSerializer.java
+++ b/src/main/java/fr/viveris/jnidbus/serialization/serializers/PrimitiveSerializer.java
@@ -1,8 +1,13 @@
 package fr.viveris.jnidbus.serialization.serializers;
 
 import fr.viveris.jnidbus.exception.MessageCheckException;
+import fr.viveris.jnidbus.exception.MessageSignatureMismatchException;
+import fr.viveris.jnidbus.serialization.serializers.primitives.BasicTypesSerializer;
+import fr.viveris.jnidbus.serialization.serializers.primitives.EnumSerializer;
+import fr.viveris.jnidbus.serialization.serializers.primitives.ObjectPathSerializer;
 import fr.viveris.jnidbus.serialization.signature.SignatureElement;
 import fr.viveris.jnidbus.serialization.signature.SupportedTypes;
+import fr.viveris.jnidbus.types.ObjectPath;
 
 import java.lang.annotation.ElementType;
 
@@ -10,46 +15,37 @@ import java.lang.annotation.ElementType;
  * The PrimitiveSerializer doesn't do much beside checking the expected type of value
  */
 public class PrimitiveSerializer extends Serializer {
-    private boolean isEnum = false;
-    private Class<? extends Enum> enumType;
-    private SupportedTypes type;
+    private static final Class<?>[] NON_BASIC_TYPES = {Enum.class, ObjectPath.class};
+
+    private Serializer nestedSerializer;
 
     public PrimitiveSerializer(Class<?> expectedType, SignatureElement signatureElement, Class managedClass, String managedFieldName) throws MessageCheckException {
         super(signatureElement,managedClass,managedFieldName );
-        this.type = signatureElement.getPrimitive();
         if(expectedType.isEnum()){
-            if(this.type != SupportedTypes.STRING && this.type != SupportedTypes.INTEGER){
-                throw new MessageCheckException("The passed primitive is an enum but the signature is not a String or Integer",managedClass,managedFieldName);
-            }
-            this.isEnum = true;
-            this.enumType = expectedType.asSubclass(Enum.class);
-        } else if(!expectedType.isAssignableFrom(signature.getPrimitive().getPrimitiveType()) &&
-                !expectedType.isAssignableFrom(signature.getPrimitive().getBoxedType())){
-            throw new MessageCheckException("The field type is not compatible with the dbus type",this.managedClass,this.managedFieldName);
+            this.nestedSerializer = new EnumSerializer(expectedType,signatureElement,managedClass,managedFieldName);
+        }else if(signatureElement.getPrimitive() == SupportedTypes.OBJ_PATH){
+            this.nestedSerializer = new ObjectPathSerializer(expectedType,signatureElement,managedClass,managedFieldName);
+        }else {
+            this.nestedSerializer = new BasicTypesSerializer(expectedType,signatureElement,managedClass,managedFieldName);
         }
     }
 
     @Override
     public Object serialize(Object value){
-        if(this.isEnum){
-            if(this.type == SupportedTypes.STRING){
-                return ((Enum)value).name();
-            }else{
-                return ((Enum)value).ordinal();
-            }
-        }
-        return value;
+        return this.nestedSerializer.serialize(value);
     }
 
     @Override
-    public Object deserialize(Object value) {
-        if(this.isEnum){
-            if(this.type == SupportedTypes.STRING){
-                return Enum.valueOf(this.enumType,(String) value);
-            }else{
-                return this.enumType.getEnumConstants()[(Integer) value];
+    public Object deserialize(Object value) throws MessageSignatureMismatchException {
+        return this.nestedSerializer.deserialize(value);
+    }
+
+    public static boolean isNonBasicType(Class<?> clazz){
+        for(Class c : PrimitiveSerializer.NON_BASIC_TYPES){
+            if(c.isAssignableFrom(clazz)){
+                return true;
             }
         }
-        return value;
+        return false;
     }
 }

--- a/src/main/java/fr/viveris/jnidbus/serialization/serializers/primitives/BasicTypesSerializer.java
+++ b/src/main/java/fr/viveris/jnidbus/serialization/serializers/primitives/BasicTypesSerializer.java
@@ -1,0 +1,28 @@
+package fr.viveris.jnidbus.serialization.serializers.primitives;
+
+import fr.viveris.jnidbus.exception.MessageCheckException;
+import fr.viveris.jnidbus.exception.MessageSignatureMismatchException;
+import fr.viveris.jnidbus.serialization.serializers.Serializer;
+import fr.viveris.jnidbus.serialization.signature.SignatureElement;
+import fr.viveris.jnidbus.serialization.signature.SupportedTypes;
+
+public class BasicTypesSerializer extends Serializer {
+
+    public BasicTypesSerializer(Class<?> expectedType, SignatureElement signatureElement, Class managedClass, String managedFieldName) throws MessageCheckException {
+        super(signatureElement,managedClass,managedFieldName );
+        if(!expectedType.isAssignableFrom(signatureElement.getPrimitive().getPrimitiveType()) &&
+                !expectedType.isAssignableFrom(signatureElement.getPrimitive().getBoxedType())){
+            throw new MessageCheckException("The field type is not compatible with the dbus type",this.managedClass,this.managedFieldName);
+        }
+    }
+
+    @Override
+    public Object serialize(Object value) {
+        return value;
+    }
+
+    @Override
+    public Object deserialize(Object value) throws MessageSignatureMismatchException {
+        return value;
+    }
+}

--- a/src/main/java/fr/viveris/jnidbus/serialization/serializers/primitives/EnumSerializer.java
+++ b/src/main/java/fr/viveris/jnidbus/serialization/serializers/primitives/EnumSerializer.java
@@ -1,0 +1,43 @@
+package fr.viveris.jnidbus.serialization.serializers.primitives;
+
+import fr.viveris.jnidbus.exception.MessageCheckException;
+import fr.viveris.jnidbus.serialization.serializers.Serializer;
+import fr.viveris.jnidbus.serialization.signature.SignatureElement;
+import fr.viveris.jnidbus.serialization.signature.SupportedTypes;
+
+public class EnumSerializer extends Serializer {
+    Class<? extends Enum> clazz;
+    SupportedTypes type;
+
+    public EnumSerializer(Class<?> expectedType, SignatureElement signatureElement, Class managedClass, String managedFieldName) throws MessageCheckException {
+        super(signatureElement, managedClass, managedFieldName);
+
+        if(!Enum.class.isAssignableFrom(expectedType)){
+            throw new MessageCheckException("The expected type should be an enum but isn't",managedClass,managedFieldName);
+        }
+
+        this.type = signatureElement.getPrimitive();
+        if(this.type != SupportedTypes.STRING && this.type != SupportedTypes.INTEGER){
+            throw new MessageCheckException("The passed primitive is an enum but the signature is not a String or Integer",managedClass,managedFieldName);
+        }
+        this.clazz = expectedType.asSubclass(Enum.class);
+    }
+
+    @Override
+    public Object serialize(Object value){
+        if(this.type == SupportedTypes.STRING){
+            return ((Enum)value).name();
+        }else{
+            return ((Enum)value).ordinal();
+        }
+    }
+
+    @Override
+    public Object deserialize(Object value) {
+        if(this.type == SupportedTypes.STRING){
+            return Enum.valueOf(this.clazz,(String) value);
+        }else{
+            return this.clazz.getEnumConstants()[(Integer) value];
+        }
+    }
+}

--- a/src/main/java/fr/viveris/jnidbus/serialization/serializers/primitives/ObjectPathSerializer.java
+++ b/src/main/java/fr/viveris/jnidbus/serialization/serializers/primitives/ObjectPathSerializer.java
@@ -1,0 +1,27 @@
+package fr.viveris.jnidbus.serialization.serializers.primitives;
+
+import fr.viveris.jnidbus.exception.MessageCheckException;
+import fr.viveris.jnidbus.exception.MessageSignatureMismatchException;
+import fr.viveris.jnidbus.serialization.serializers.Serializer;
+import fr.viveris.jnidbus.serialization.signature.SignatureElement;
+import fr.viveris.jnidbus.types.ObjectPath;
+
+public class ObjectPathSerializer extends Serializer {
+
+    public ObjectPathSerializer(Class<?> expectedType, SignatureElement signatureElement, Class managedClass, String managedFieldName) throws MessageCheckException {
+        super(signatureElement,managedClass,managedFieldName );
+        if(!ObjectPath.class.isAssignableFrom(expectedType)){
+            throw new MessageCheckException("The field type should be ObjectPath",this.managedClass,this.managedFieldName);
+        }
+    }
+
+    @Override
+    public Object serialize(Object value) {
+        return ((ObjectPath)value).getPath();
+    }
+
+    @Override
+    public Object deserialize(Object value) throws MessageSignatureMismatchException {
+        return new ObjectPath((String) value);
+    }
+}

--- a/src/main/java/fr/viveris/jnidbus/serialization/signature/SupportedTypes.java
+++ b/src/main/java/fr/viveris/jnidbus/serialization/signature/SupportedTypes.java
@@ -3,6 +3,8 @@
  */
 package fr.viveris.jnidbus.serialization.signature;
 
+import fr.viveris.jnidbus.types.ObjectPath;
+
 import java.lang.reflect.Array;
 
 /**
@@ -10,7 +12,7 @@ import java.lang.reflect.Array;
  */
 public enum SupportedTypes {
     STRING('s',String.class,String.class),
-    OBJ_PATH('o',String.class,String.class),
+    OBJ_PATH('o', ObjectPath.class,ObjectPath.class),
     INTEGER('i',Integer.TYPE,Integer.class),
     BOOLEAN('b',Boolean.TYPE,Boolean.class),
     BYTE('y',Byte.TYPE,Byte.class),

--- a/src/main/java/fr/viveris/jnidbus/serialization/signature/SupportedTypes.java
+++ b/src/main/java/fr/viveris/jnidbus/serialization/signature/SupportedTypes.java
@@ -10,6 +10,7 @@ import java.lang.reflect.Array;
  */
 public enum SupportedTypes {
     STRING('s',String.class,String.class),
+    OBJ_PATH('o',String.class,String.class),
     INTEGER('i',Integer.TYPE,Integer.class),
     BOOLEAN('b',Boolean.TYPE,Boolean.class),
     BYTE('y',Byte.TYPE,Byte.class),
@@ -54,6 +55,7 @@ public enum SupportedTypes {
     public static SupportedTypes forChar(char c){
         switch(c){
             case 's': return STRING;
+            case 'o': return OBJ_PATH;
             case 'i': return INTEGER;
             case 'b': return BOOLEAN;
             case 'y': return BYTE;

--- a/src/main/java/fr/viveris/jnidbus/types/ObjectPath.java
+++ b/src/main/java/fr/viveris/jnidbus/types/ObjectPath.java
@@ -1,0 +1,33 @@
+package fr.viveris.jnidbus.types;
+
+import java.util.Objects;
+
+public class ObjectPath {
+    private String path;
+
+    public ObjectPath(String path){
+        //TODO: implement format check
+        this.path = path;
+    }
+
+    public String getPath() {
+        return path;
+    }
+
+    public void setPath(String path) {
+        this.path = path;
+    }
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) return true;
+        if (!(o instanceof ObjectPath)) return false;
+        ObjectPath that = (ObjectPath) o;
+        return path.equals(that.path);
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(path);
+    }
+}

--- a/src/main/java/fr/viveris/jnidbus/types/ObjectPath.java
+++ b/src/main/java/fr/viveris/jnidbus/types/ObjectPath.java
@@ -1,12 +1,14 @@
 package fr.viveris.jnidbus.types;
 
 import java.util.Objects;
+import java.util.regex.Pattern;
 
 public class ObjectPath {
+    private static final Pattern format = Pattern.compile("^\\/([a-zA-Z1-9_]+\\/?)+(?<!\\/)$");
     private String path;
 
     public ObjectPath(String path){
-        //TODO: implement format check
+        if(!this.matchFormat(path)) throw new IllegalArgumentException("The given path do not respect the DBus object path format");
         this.path = path;
     }
 
@@ -15,6 +17,7 @@ public class ObjectPath {
     }
 
     public void setPath(String path) {
+        if(!this.matchFormat(path)) throw new IllegalArgumentException("The given path do not respect the DBus object path format");
         this.path = path;
     }
 
@@ -29,5 +32,9 @@ public class ObjectPath {
     @Override
     public int hashCode() {
         return Objects.hash(path);
+    }
+
+    private boolean matchFormat(String path){
+        return format.matcher(path).matches();
     }
 }

--- a/src/main/jni/src/Serialization.cpp
+++ b/src/main/jni/src/Serialization.cpp
@@ -291,10 +291,11 @@ void serialize_element(context* ctx, int dbus_type, jobject object, DBusMessageI
     
     switch(dbus_type){
         case DBUS_TYPE_STRING:
+        case DBUS_TYPE_OBJECT_PATH:
         {
             //get native string, add and release
             const char* valueNative = env->GetStringUTFChars((jstring)object, 0);
-            dbus_message_iter_append_basic(container, DBUS_TYPE_STRING, &valueNative);
+            dbus_message_iter_append_basic(container, dbus_type, &valueNative);
             env->ReleaseStringUTFChars((jstring) object, valueNative);
             break;
         }
@@ -417,6 +418,7 @@ jobject deserialize_element(context* ctx, DBusMessageIter* container){
 
     switch(dbus_message_iter_get_arg_type(container)){
         case DBUS_TYPE_STRING:
+        case DBUS_TYPE_OBJECT_PATH:
         {
             char* value;
             dbus_message_iter_get_basic(container, &value);

--- a/src/test/java/fr/viveris/jnidbus/test/common/DBusObjects/primitives/ObjectPathMessage.java
+++ b/src/test/java/fr/viveris/jnidbus/test/common/DBusObjects/primitives/ObjectPathMessage.java
@@ -5,6 +5,7 @@ package fr.viveris.jnidbus.test.common.DBusObjects.primitives;
 
 import fr.viveris.jnidbus.message.Message;
 import fr.viveris.jnidbus.serialization.DBusType;
+import fr.viveris.jnidbus.types.ObjectPath;
 
 import java.util.List;
 
@@ -13,22 +14,22 @@ import java.util.List;
         fields = {"primitive","list"}
 )
 public class ObjectPathMessage extends Message {
-    private String primitive;
-    private List<String> list;
+    private ObjectPath primitive;
+    private List<ObjectPath> list;
 
-    public String getPrimitive() {
+    public ObjectPath getPrimitive() {
         return primitive;
     }
 
-    public void setPrimitive(String primitive) {
+    public void setPrimitive(ObjectPath primitive) {
         this.primitive = primitive;
     }
 
-    public List<String> getList() {
+    public List<ObjectPath> getList() {
         return list;
     }
 
-    public void setList(List<String> list) {
+    public void setList(List<ObjectPath> list) {
         this.list = list;
     }
 }

--- a/src/test/java/fr/viveris/jnidbus/test/common/DBusObjects/primitives/ObjectPathMessage.java
+++ b/src/test/java/fr/viveris/jnidbus/test/common/DBusObjects/primitives/ObjectPathMessage.java
@@ -1,0 +1,34 @@
+/* Copyright 2019, Viveris Technologies <opensource@toulouse.viveris.fr>
+ * Distributed under the terms of the Academic Free License.
+ */
+package fr.viveris.jnidbus.test.common.DBusObjects.primitives;
+
+import fr.viveris.jnidbus.message.Message;
+import fr.viveris.jnidbus.serialization.DBusType;
+
+import java.util.List;
+
+@DBusType(
+        signature = "oao",
+        fields = {"primitive","list"}
+)
+public class ObjectPathMessage extends Message {
+    private String primitive;
+    private List<String> list;
+
+    public String getPrimitive() {
+        return primitive;
+    }
+
+    public void setPrimitive(String primitive) {
+        this.primitive = primitive;
+    }
+
+    public List<String> getList() {
+        return list;
+    }
+
+    public void setList(List<String> list) {
+        this.list = list;
+    }
+}

--- a/src/test/java/fr/viveris/jnidbus/test/common/handlers/primitives/ObjectPathHandler.java
+++ b/src/test/java/fr/viveris/jnidbus/test/common/handlers/primitives/ObjectPathHandler.java
@@ -1,0 +1,45 @@
+/* Copyright 2019, Viveris Technologies <opensource@toulouse.viveris.fr>
+ * Distributed under the terms of the Academic Free License.
+ */
+package fr.viveris.jnidbus.test.common.handlers.primitives;
+
+import fr.viveris.jnidbus.dispatching.MemberType;
+import fr.viveris.jnidbus.dispatching.annotation.Handler;
+import fr.viveris.jnidbus.dispatching.annotation.HandlerMethod;
+import fr.viveris.jnidbus.remote.RemoteInterface;
+import fr.viveris.jnidbus.remote.RemoteMember;
+import fr.viveris.jnidbus.remote.Signal;
+import fr.viveris.jnidbus.test.common.DBusObjects.primitives.BooleanMessage;
+import fr.viveris.jnidbus.test.common.DBusObjects.primitives.ObjectPathMessage;
+import fr.viveris.jnidbus.test.common.handlers.CommonHandler;
+
+@Handler(
+        path = "/handlers/primitive/object_path",
+        interfaceName = "Handlers.Primitive.ObjectPathHandler"
+)
+public class ObjectPathHandler extends CommonHandler<ObjectPathMessage> {
+
+    @HandlerMethod(
+            member = "handle",
+            type = MemberType.SIGNAL
+    )
+    public void handle(ObjectPathMessage msg){
+        this.doHandle(msg);
+    }
+
+    @Override
+    public Signal<ObjectPathMessage> buildSignal(ObjectPathMessage value) {
+        return new ObjectPathHandlerRemote.ObjectPathSignal(value);
+    }
+
+    @RemoteInterface("Handlers.Primitive.ObjectPathHandler")
+    public interface ObjectPathHandlerRemote{
+
+        @RemoteMember("handle")
+        class ObjectPathSignal extends Signal<ObjectPathMessage> {
+            public ObjectPathSignal(ObjectPathMessage params) {
+                super(params);
+            }
+        }
+    }
+}

--- a/src/test/java/fr/viveris/jnidbus/test/serialization/PrimitiveTypesSerializationTest.java
+++ b/src/test/java/fr/viveris/jnidbus/test/serialization/PrimitiveTypesSerializationTest.java
@@ -97,6 +97,11 @@ public class PrimitiveTypesSerializationTest extends SerializationTestCase {
         assertArrayEquals(Arrays.asList(new ObjectPath("/d/e/f"),new ObjectPath("/h/i/j")).toArray(),received.getList().toArray());
     }
 
+    @Test(expected = IllegalArgumentException.class)
+    public void testWrongObjectPathFormat(){
+        ObjectPath path = new ObjectPath("a//b/c/");
+    }
+
     @Test
     public void enumTest() throws InterruptedException {
         EnumMessage msg = new EnumMessage();

--- a/src/test/java/fr/viveris/jnidbus/test/serialization/PrimitiveTypesSerializationTest.java
+++ b/src/test/java/fr/viveris/jnidbus/test/serialization/PrimitiveTypesSerializationTest.java
@@ -85,4 +85,14 @@ public class PrimitiveTypesSerializationTest extends SerializationTestCase {
         assertEquals(2.2,received.getBoxed(),0);
         assertEquals(3.3,received.getList().get(0),0);
     }
+
+    @Test
+    public void objectPathTest() throws InterruptedException {
+        ObjectPathMessage msg = new ObjectPathMessage();
+        msg.setPrimitive("/a/b/c");
+        msg.setList(Arrays.asList("/d/e/f","/h/i/j"));
+        ObjectPathMessage received = this.sendAndReceive(new ObjectPathHandler(), msg);
+        assertEquals("/a/b/c",received.getPrimitive());
+        assertArrayEquals(Arrays.asList("/d/e/f","/h/i/j").toArray(),received.getList().toArray());
+    }
 }

--- a/src/test/java/fr/viveris/jnidbus/test/serialization/PrimitiveTypesSerializationTest.java
+++ b/src/test/java/fr/viveris/jnidbus/test/serialization/PrimitiveTypesSerializationTest.java
@@ -5,6 +5,7 @@ package fr.viveris.jnidbus.test.serialization;
 
 import fr.viveris.jnidbus.test.common.DBusObjects.primitives.*;
 import fr.viveris.jnidbus.test.common.handlers.primitives.*;
+import fr.viveris.jnidbus.types.ObjectPath;
 import org.junit.Test;
 
 import java.util.Arrays;
@@ -89,11 +90,11 @@ public class PrimitiveTypesSerializationTest extends SerializationTestCase {
     @Test
     public void objectPathTest() throws InterruptedException {
         ObjectPathMessage msg = new ObjectPathMessage();
-        msg.setPrimitive("/a/b/c");
-        msg.setList(Arrays.asList("/d/e/f","/h/i/j"));
+        msg.setPrimitive(new ObjectPath("/a/b/c"));
+        msg.setList(Arrays.asList(new ObjectPath("/d/e/f"),new ObjectPath("/h/i/j")));
         ObjectPathMessage received = this.sendAndReceive(new ObjectPathHandler(), msg);
-        assertEquals("/a/b/c",received.getPrimitive());
-        assertArrayEquals(Arrays.asList("/d/e/f","/h/i/j").toArray(),received.getList().toArray());
+        assertEquals(new ObjectPath("/a/b/c"),received.getPrimitive());
+        assertArrayEquals(Arrays.asList(new ObjectPath("/d/e/f"),new ObjectPath("/h/i/j")).toArray(),received.getList().toArray());
     }
 
     @Test


### PR DESCRIPTION
Refactor primitive types serialization, we now have "basic" types that do not need any kind of processing from Java and other primitive types that do (ex: object_path, enums) and implement object_path support